### PR TITLE
Allow default urls in package.xml

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,59 +5,89 @@
 [![Codacy Badge][codacy-img]][codacy-link]
 [![Codacy coverage][codacy-coverage-img]][codacy-coverage-link]
 
-Defines new verb `dependencies` (or in short `deps`) 
+Defines new verb `dependencies` (or in short `deps`)
 and its sub-verbs `fetch` and `update` for
-[catkin_tools](https://github.com/catkin/catkin_tools). 
-This verb is responsible for downloading external dependencies 
-of the projects in a `catkin` workspace and keeping them up to date. 
-For now only `git` is supported. The tool is under heavy development. 
-Please use PyPI or download a tag for stable version.
+[catkin_tools](https://github.com/catkin/catkin_tools).
+This verb is responsible for downloading external dependencies
+of the projects in a `catkin` workspace and keeping them up to date.
+For now only `git` is supported. The tool is under heavy development.
+Please use PyPI or download a tag for a stable version.
 
 ## How to install ##
-This package installs a new verb. You need to have `catkin_tools` installed.
-Currently the easiest way to install this verb is from `PyPI`:
+This package installs a new verb for `catkin_tools`.
+The easiest way to install this verb is from `PyPI`:
 ```
 [sudo] pip install catkin_tools_fetch
 ```
 
 ## How to use ##
-Both available subverbs should be used after `dependencies` verb 
-(or its shorter version `deps`) from within of a catkin workspace.
+Both available subverbs should be used after `dependencies` verb (or its
+shorter version `deps`) from within of a catkin workspace. Below are short
+showcases on usage of the verbs. Optional arguments are shown in brackets.
 ### `fetch` ###
-```
-catkin dependencies fetch --default_url YOUR_DEFAULT_URL
+```bash
+# Longer version:
+catkin dependencies fetch [--default_urls URL1,URL2,URL3] [TARGET_PKG]
+# Equivalent shorter version:
+catkin deps fetch [--default_urls URL1,URL2,URL3] [TARGET_PKG]
 ```
 
 ### `update` ###
+```bash
+# Longer version:
+catkin dependencies update [TARGET_PKG]
+# Equivalent shorter version:
+catkin deps update [TARGET_PKG]
 ```
-catkin dependencies update
+
+## How `fetch` works ##
+This command will look inside the `src/` folder of the current catkin workspace
+and will analyze the dependencies of each `package.xml` file for each project
+in this workspace (or, if `TARGET_PKG` is provided, only of this package). Then
+`fetch` will try to clone the dependencies looking for them under urls:
+```
+[URL1/DEP_NAME, URL1/DEP_NAME, URL1/DEP_NAME]
 ```
 
-This commands will look inside the `src/` folder of the current catkin workspace
-and will analyze the dependencies of `package.xml` files for each project in
-this workspace. Then `fetch` will try to clone the packages looking for them under
-url: `YOUR_DEFAULT_URL/PACKAGE_NAME`. The `update` subverb will try to pull any 
-changes from the server to any package in the workspace if there is no change locally.
+The verb `fetch` is smart enough to recognize `ssh` and `https` access, thus
+these expansions for a given `DEP_NAME` are valid:
+```
+git@path     --> git@path/DEP_NAME.git
+https://path --> https://path/DEP_NAME.git
+```
+Beware, though, that for ssh access your machine has to have proper ssh keys
+installed.
 
-Additionaly, one can explicitly define a url or a branch for a dependency in
-`package.xml` file under `<export>` tag. For example:
-
+Additionaly, one can explicitly define needed urls for dependencies in
+`package.xml` of your `TARGET_PKG` file under `<export>` tag. For example:
 ```xml
 <export>
-    <git_url target="PACKAGE_NAME" url="PACKAGE_URL" branch="BRANCH_NAME" />
+    <!-- Define a url for all packages with no explicit url defined. -->
+    <git_url target="all" url="SOME_GENERAL_URL" />
+    <!-- Define an explicit url for package DEP_NAME. -->
+    <git_url target="DEP_NAME" url="git@some_path/DEP_NAME.git" branch="BRANCH_NAME" />
 </export>
 ```
 
-Here `PACKAGE_NAME` is the name of your package and `PACKAGE_URL` is the full
-url to your package in git and `BRANCH_NAME` is the branch you want to
-checkout.
+There are some options here:
+- If the `target` is set to `"all"`, then `SOME_GENERAL_URL` is treated as one
+  of the default urls to search all packages in.
+- If the `target` package `"DEP_NAME"` matches one of the dependencies,
+  this has precedence over any of the default urls and the package will be
+  searched in the full path to the package defined in the `url` field.
+  Additionaly, branch `"BRANCH_NAME"` will be checked out after cloning.
 
-Any of these can be skipped. The default will be used instead.
+Any of these can be skipped. The default urls will be used instead.
+
+## How `update` works ##
+The `update` subverb will try to pull any changes from the server to any
+package in the workspace (or `TARGET_PKG` if specified) if there is no change
+locally. If there are local uncommited changes `update` will do nothing for
+those packages. There is no need to provide any urls here as every package
+knows its git remote.
 
 ## Misc ##
 You can always use `--help` flag to find out more about each command and arguments.
-
-You can also use a shorter version of the verb `deps` instead of a full verb `dependencies`.
 
 [codacy-img]: https://img.shields.io/codacy/grade/9c050cd8852046ae863c940b8409f9ea.svg?style=flat-square
 [codacy-coverage-img]: https://img.shields.io/codacy/coverage/9c050cd8852046ae863c940b8409f9ea.svg?style=flat-square

--- a/catkin_tools_fetch/__init__.py
+++ b/catkin_tools_fetch/__init__.py
@@ -13,16 +13,7 @@
 # limitations under the License.
 
 from .cli import main
-from .cli import prepare_arguments
 from .cli import prepare_arguments_deps
-
-# This describes this command to the loader
-description = dict(
-    verb='fetch',
-    description='Fetch dependencies of packages in the workspace',
-    main=main,
-    prepare_arguments=prepare_arguments,
-)
 
 # This describes this command to the loader
 description_deps = dict(

--- a/catkin_tools_fetch/cli.py
+++ b/catkin_tools_fetch/cli.py
@@ -220,7 +220,6 @@ It has the same interface. The old command will be removed in future.
         return update(packages=opts.packages,
                       workspace=opts.workspace,
                       context=context,
-                      default_url=default_url,
                       conflict_strategy=opts.on_conflict,
                       use_preprint=use_preprint,
                       num_threads=opts.num_threads)
@@ -229,7 +228,6 @@ It has the same interface. The old command will be removed in future.
 def update(packages,
            workspace,
            context,
-           default_url,
            conflict_strategy,
            use_preprint,
            num_threads):
@@ -239,7 +237,6 @@ def update(packages,
         packages (list): A list of packages provided by the user.
         workspace (str): Path to a workspace (without src/ in the end).
         context (Context): Current context. Needed to find current packages.
-        default_url (str): A default url with a {package} placeholder in it.
         use_preprint (bool): Show status messages while cloning
 
     Returns:
@@ -314,6 +311,8 @@ def fetch(packages,
                     # we must analyze their dependencies too even if we wanted
                     # to download dependencies for one project only.
                     packages.add(new_dep_name)
+                # Update default url to use the new version of it further on.
+                default_url = parser.default_url
         try:
             downloader = Downloader(ws_path=ws_path,
                                     available_pkgs=available_pkgs,

--- a/catkin_tools_fetch/cli.py
+++ b/catkin_tools_fetch/cli.py
@@ -31,55 +31,6 @@ logging.basicConfig()
 log = logging.getLogger('deps')
 
 
-def prepare_arguments(parser):
-    """Parse arguments that belong to this verb.
-
-    Args:
-        parser (argparser): Argument parser
-
-    Returns:
-        argparser: Parser that knows about our flags.
-    """
-    parser.description = """ Download dependencies for one or more packages in
-        a catkin workspace. This reads dependencies from package.xml file of
-        each of the packages in the workspace and tries to download their
-        sources from version control system of choice."""
-    add_context_args(parser)
-
-    packages_help_msg = """
-        Packages for which the dependencies are analyzed.
-        If no packages are given, all packages are processed."""
-    fetch_group = parser.add_argument_group(
-        'Packages',
-        'Control for which packages we fetch dependencies.')
-
-    fetch_group.add_argument('packages',
-                             metavar='PKGNAME',
-                             nargs='*',
-                             help=packages_help_msg)
-
-    # add config flags to all groups that need it
-    config_group = parser.add_argument_group('Config')
-    config_group.add_argument(
-        '--default_url', default="{package}",
-        help='Where to look for packages by default.')
-    config_group.add_argument('--no_status', action='store_true',
-                              help='Do not use progress status when cloning.')
-    config_group.add_argument('--num_threads', '-j',
-                              type=int,
-                              default=4,
-                              help='Number of threads run in parallel.')
-
-    # Behavior
-    behavior_group = parser.add_argument_group(
-        'Interface', 'The behavior of the command-line interface.')
-    add = behavior_group.add_argument
-    add('--verbose', '-v', action='store_true', default=False,
-        help='Print output from commands.')
-
-    return parser
-
-
 def prepare_arguments_deps(parser):
     """Parse arguments that belong to this verb.
 
@@ -100,7 +51,10 @@ def prepare_arguments_deps(parser):
     # add config flags to all groups that need it
     parent_parser.add_argument(
         '--default_url', default="{package}",
-        help='Where to look for packages by default.')
+        help='[deprecated] Where to look for packages by default.')
+    parent_parser.add_argument(
+        '--default_urls', default="{package}",
+        help='A comma separated list of urls where to look for packages at.')
 
     # Behavior
     parent_parser.add_argument('--verbose', '-v',
@@ -163,7 +117,7 @@ def prepare_arguments_deps(parser):
 
 
 def main(opts):
-    """Main function for fetch verb.
+    """Run the script.
 
     Args:
         opts (dict): Options populated by an arg parser.
@@ -188,32 +142,18 @@ def main(opts):
     log.info(" Using %s threads.", opts.num_threads)
 
     context = Context.load(opts.workspace, opts.profile, opts, append=True)
-    default_url = Tools.prepare_default_url(opts.default_url)
+    if opts.default_urls != opts.default_url:
+        opts.default_urls += "," + opts.default_url
+    # Prepare the set of default urls
+    default_urls = Tools.prepare_default_urls(opts.default_urls)
     if not opts.workspace:
         log.critical(" Workspace undefined! Abort!")
         return 1
     if opts.verb == 'fetch' or opts.subverb == 'fetch':
-        if opts.verb == 'fetch':
-            msg = """
-############################# DEPRECATED ###################################
-You are using an old deprecated command: `catkin fetch`.
-Please use the new command instead:
-
-                `catkin fetch` --> `catkin deps fetch`
-
-It has the same interface. The old command will be removed in future.
-############################################################################
-            """
-            log.warning(msg)
-            seconds_to_sleep = 5
-            log.info(" Showing deprecation banner for %s seconds.",
-                     seconds_to_sleep)
-            from time import sleep
-            sleep(seconds_to_sleep)
         return fetch(packages=opts.packages,
                      workspace=opts.workspace,
                      context=context,
-                     default_url=default_url,
+                     default_urls=default_urls,
                      use_preprint=use_preprint,
                      num_threads=opts.num_threads)
     if opts.subverb == 'update':
@@ -258,7 +198,7 @@ def update(packages,
 def fetch(packages,
           workspace,
           context,
-          default_url,
+          default_urls,
           use_preprint,
           num_threads):
     """Fetch dependencies of a package.
@@ -267,7 +207,7 @@ def fetch(packages,
         packages (list): A list of packages provided by the user.
         workspace (str): Path to a workspace (without src/ in the end).
         context (Context): Current context. Needed to find current packages.
-        default_url (str): A default url with a {package} placeholder in it.
+        default_urls (set(str)): A set of urls where we search for packages.
         use_preprint (bool): Show status messages while cloning
 
     Returns:
@@ -298,7 +238,8 @@ def fetch(packages,
             if package.name in already_fetched:
                 continue
             if fetch_all or (package.name in packages):
-                parser = Parser(default_url, package.name)
+                parser = Parser(default_urls=default_urls,
+                                pkg_name=package.name)
                 package_folder = path.join(ws_path, package_path)
                 deps_to_fetch = Tools.update_deps_dict(
                     deps_to_fetch, parser.get_dependencies(package_folder))
@@ -312,7 +253,7 @@ def fetch(packages,
                     # to download dependencies for one project only.
                     packages.add(new_dep_name)
                 # Update default url to use the new version of it further on.
-                default_url = parser.default_url
+                default_urls.update(parser.default_urls)
         try:
             downloader = Downloader(ws_path=ws_path,
                                     available_pkgs=available_pkgs,

--- a/catkin_tools_fetch/cli.py
+++ b/catkin_tools_fetch/cli.py
@@ -99,7 +99,7 @@ def prepare_arguments_deps(parser):
 
     # add config flags to all groups that need it
     parent_parser.add_argument(
-        '--default_url', default="{package}",
+        '--default_url', default="",
         help='Where to look for packages by default.')
 
     # Behavior

--- a/catkin_tools_fetch/cli.py
+++ b/catkin_tools_fetch/cli.py
@@ -142,7 +142,7 @@ def main(opts):
     log.info(" Using %s threads.", opts.num_threads)
 
     context = Context.load(opts.workspace, opts.profile, opts, append=True)
-    if opts.default_urls != opts.default_url:
+    if opts.default_url != Tools.PACKAGE_TAG:
         opts.default_urls += "," + opts.default_url
     # Prepare the set of default urls
     default_urls = Tools.prepare_default_urls(opts.default_urls)

--- a/catkin_tools_fetch/cli.py
+++ b/catkin_tools_fetch/cli.py
@@ -99,7 +99,7 @@ def prepare_arguments_deps(parser):
 
     # add config flags to all groups that need it
     parent_parser.add_argument(
-        '--default_url', default="",
+        '--default_url', default="{package}",
         help='Where to look for packages by default.')
 
     # Behavior

--- a/catkin_tools_fetch/lib/dependency_parser.py
+++ b/catkin_tools_fetch/lib/dependency_parser.py
@@ -74,7 +74,7 @@ class Parser(object):
         if '{package}' not in default_url:
             raise ValueError(
                 '`default_url` must contain a "{package}" placeholder.')
-        self.__default_url = default_url
+        self.default_url = default_url
         self.pkg_name = pkg_name
         self.printer = Printer()
 
@@ -103,7 +103,7 @@ class Parser(object):
         self.printer.print_msg(msg)
         log.debug(" Dependencies: %s", all_deps)
         deps_with_urls = self.__init_dep_dict(all_deps)
-        return Parser.__update_explicit_values(xmldoc, deps_with_urls)
+        return self.__update_explicit_values(xmldoc, deps_with_urls)
 
     @staticmethod
     def __fix_dependencies(deps, pkg_name):
@@ -125,8 +125,7 @@ class Parser(object):
                     pkg_name, dep, fixed_deps[i])
         return fixed_deps
 
-    @staticmethod
-    def __update_explicit_values(xmldoc, dep_dict):
+    def __update_explicit_values(self, xmldoc, dep_dict):
         """Specify explicit values instead of default ones.
 
         A user can define explicit values for each package in the <export> tag.
@@ -142,7 +141,6 @@ class Parser(object):
         Returns:
             dict: A dict with final dependencies parsed from <export> tags
         """
-        default_url = Tools.PACKAGE_TAG  # Initial default value.
         for url_tag in Parser.URL_TAGS:
             urls_node = xmldoc.getElementsByTagName(url_tag)
             for item in urls_node:
@@ -155,7 +153,7 @@ class Parser(object):
                 if url:
                     if target == 'all':
                         # The target is 'all' so this denotes a default url.
-                        default_url = Tools.prepare_default_url(url)
+                        self.default_url = Tools.prepare_default_url(url)
                         continue
                     # Here we assume url is a full explicit url to package.
                     dep_dict[target].url = url
@@ -167,7 +165,7 @@ class Parser(object):
                 log.debug(" updated dependency: %s", dep_dict[target])
         # Update the default urls for all dependencies
         for dep in dep_dict.values():
-            dep.update_url_from_default_if_needed(default_url)
+            dep.update_url_from_default_if_needed(self.default_url)
         return dep_dict
 
     @staticmethod

--- a/catkin_tools_fetch/lib/dependency_parser.py
+++ b/catkin_tools_fetch/lib/dependency_parser.py
@@ -101,7 +101,7 @@ class Parser(object):
             deps = Parser.__node_to_list(xmldoc, tag)
             deps = Parser.__fix_dependencies(deps, self.pkg_name)
             all_deps += deps
-        msg = " {}: Found {} dependencies".format(
+        msg = " {}: Found {} valid dependencies".format(
             Tools.decorate(self.pkg_name), len(all_deps))
         self.printer.print_msg(msg)
         log.debug(" Dependencies: %s", all_deps)

--- a/catkin_tools_fetch/lib/dependency_parser.py
+++ b/catkin_tools_fetch/lib/dependency_parser.py
@@ -62,16 +62,19 @@ class Parser(object):
     TAGS = ["build_depend", "depend"]
     URL_TAGS = ["git_url"]
 
-    def __init__(self, download_mask, pkg_name):
+    def __init__(self, default_url, pkg_name):
         """Initialize a dependency parser.
 
         Args:
-            download_mask (str): a mask containing {package} tag to be replaced
+            default_url (str): a mask containing {package} tag to be replaced
                 later, e.g. git@<path>/{package}.git
             pkg_name (str): Name of current package
         """
         super(Parser, self).__init__()
-        self.__download_mask = download_mask
+        if '{package}' not in default_url:
+            raise ValueError(
+                '`default_url` must contain a "{package}" placeholder.')
+        self.__default_url = default_url
         self.pkg_name = pkg_name
         self.printer = Printer()
 
@@ -188,8 +191,7 @@ class Parser(object):
         """
         dep_dict = {}
         for dep_name in all_deps_list:
-            url = self.__download_mask.format(package=dep_name)
-            dependency = Dependency(name=dep_name, url=url)
+            dependency = Dependency(name=dep_name)
             dep_dict[dep_name] = dependency
         return dep_dict
 

--- a/catkin_tools_fetch/lib/downloader.py
+++ b/catkin_tools_fetch/lib/downloader.py
@@ -27,6 +27,7 @@ class Downloader(object):
 
     IGNORE_TAG = colored("[IGNORED]", 'yellow')
     NOT_FOUND_TAG = colored("[NOT FOUND]", 'red')
+    FOUND_TAG = colored("[FOUND]", 'green') + ': '
     CLONING_TAG = "[CLONING]"
     CHECKING_TAG = "[CHECKING]"
 
@@ -149,19 +150,17 @@ class Downloader(object):
         futures_list = []
         log.info(" Checking merged dependencies:")
         for dependency in dep_dict.values():
-            log.debug(" check dep: %s", dependency)
+            log.debug(" Check dependency: %s", dependency)
             if dependency.name in self.ignore_pkgs:
-                msg = " {}: {}".format(
-                    Tools.decorate(dependency.name), Downloader.IGNORE_TAG)
-                self.printer.add_msg(dependency.name, msg)
+                log.debug(" Skipping ignored package '%s'", dependency.name)
                 continue
             futures_list.append(self.thread_pool.submit(
                 self.__check_dependency, dependency))
         for future in futures.as_completed(futures_list):
             dependency, repo_found = future.result()
             if repo_found:
-                msg = " {}: {}".format(
-                    Tools.decorate(dependency.name), dependency.url)
+                msg = " {}: {}".format(Tools.decorate(dependency.name),
+                                       Downloader.FOUND_TAG + dependency.url)
                 self.printer.purge_msg(dependency.name, msg)
                 checked_deps[dependency.name] = dependency
             else:

--- a/catkin_tools_fetch/lib/tools.py
+++ b/catkin_tools_fetch/lib/tools.py
@@ -115,6 +115,8 @@ class Tools(object):
         default_ros_packages (str[]): default packages for ROS
     """
 
+    PACKAGE_TAG = '{package}'
+
     @staticmethod
     def prepare_default_url(default_url):
         """Insert {package} statement into the URL.
@@ -127,15 +129,14 @@ class Tools(object):
         Returns:
             str: Url with {package} tag placed inside of it.
         """
-        package_tag = '{package}'
-        if len(default_url) == 0:
+        if not default_url:
             return default_url
         if not default_url.endswith('/'):
             default_url += '/'
         if default_url.startswith('git'):
-            return default_url + package_tag + '.git'
+            return default_url + Tools.PACKAGE_TAG + '.git'
         if default_url.startswith('http'):
-            return default_url + package_tag
+            return default_url + Tools.PACKAGE_TAG
         return default_url
 
     @staticmethod

--- a/catkin_tools_fetch/lib/tools.py
+++ b/catkin_tools_fetch/lib/tools.py
@@ -82,17 +82,28 @@ class GitBridge(object):
         Returns:
             bool: True if exists, False otherwise
         """
-        if dependency.url == "":
-            return dependency, False
-        git_cmd = GitBridge.CHECK_CMD_MASK.format(url=dependency.url)
-        try:
-            subprocess.check_call(git_cmd,
-                                  stdout=subprocess.PIPE,
-                                  stderr=subprocess.PIPE,
-                                  shell=True)
-            return dependency, True
-        except subprocess.CalledProcessError:
-            return dependency, False
+        urls = []
+        if dependency.url:
+            urls.append(dependency.url)
+        else:
+            urls.extend(dependency.default_urls)
+        for url in urls:
+            git_cmd = GitBridge.CHECK_CMD_MASK.format(url=url)
+            try:
+                log.debug("Searching for package '%s' under url '%s'",
+                          dependency.name, url)
+                subprocess.check_call(git_cmd,
+                                      stdout=subprocess.PIPE,
+                                      stderr=subprocess.PIPE,
+                                      shell=True)
+                # Update the working url if needed.
+                dependency.url = url
+                return dependency, True
+            except subprocess.CalledProcessError:
+                log.debug('Package "%s" was not found under: "%s"',
+                          dependency.name, url)
+        # If we reached here we failed to find the dependency.
+        return dependency, False
 
     @staticmethod
     def get_branch_name(git_status_output):
@@ -118,26 +129,64 @@ class Tools(object):
     PACKAGE_TAG = '{package}'
 
     @staticmethod
-    def prepare_default_url(default_url):
+    def prepare_default_urls(default_urls):
         """Insert {package} statement into the URL.
 
         Args:
-            default_url (str): Defatul url. Can be one of the following styles:
+            default_urls (str): Default urls, single string, comma separated.
+                Each can be one of the following styles:
+                - git@<path>
+                - https://<path>
+
+        Returns:
+            set(str): Urls with {package} tag placed inside of them.
+        """
+        all_urls = default_urls.split(",")
+        prepared_urls = set()
+        for url in all_urls:
+            prepared_url = Tools.prepare_default_url(url)
+            if prepared_url:
+                prepared_urls.add(prepared_url)
+                log.debug("Prepared url: '%s'", prepared_url)
+        return prepared_urls
+
+    @staticmethod
+    def prepare_default_url(url):
+        """Insert {package} statement into the URL.
+
+        Args:
+            url (str): Default url, single string.
+                Can be one of the following styles:
                 - git@<path>
                 - https://<path>
 
         Returns:
             str: Url with {package} tag placed inside of it.
         """
-        if not default_url:
-            return default_url
-        if not default_url.endswith('/'):
-            default_url += '/'
-        if default_url.startswith('git'):
-            return default_url + Tools.PACKAGE_TAG + '.git'
-        if default_url.startswith('http'):
-            return default_url + Tools.PACKAGE_TAG
-        return default_url
+        if Tools.PACKAGE_TAG in url:
+            return url
+        if not url.endswith('/') and not url.endswith('.git'):
+            url += '/'
+        if url.startswith('git'):
+            if not url.endswith('.git'):
+                return url + Tools.PACKAGE_TAG + '.git'
+            if Tools.PACKAGE_TAG not in url:
+                log.error("Skipping url with no tag place:'%s'", url)
+                return None
+        if url.startswith('http'):
+            return url + Tools.PACKAGE_TAG
+
+    @staticmethod
+    def populate_urls_with_name(urls, pkg_name):
+        """Populate all urls with the package name."""
+        populated_urls = []
+        for url in urls:
+            if Tools.PACKAGE_TAG not in url:
+                log.error("Url '%s' is malformed. Should contain tag: '%s'",
+                          url, Tools.PACKAGE_TAG)
+                continue
+            populated_urls.append(url.format(package=pkg_name))
+        return populated_urls
 
     @staticmethod
     def list_all_ros_pkgs():

--- a/catkin_tools_fetch/lib/tools.py
+++ b/catkin_tools_fetch/lib/tools.py
@@ -87,10 +87,11 @@ class GitBridge(object):
             urls.append(dependency.url)
         else:
             urls.extend(dependency.default_urls)
+        log.debug(" Checking urls: %s", urls)
         for url in urls:
             git_cmd = GitBridge.CHECK_CMD_MASK.format(url=url)
             try:
-                log.debug("Searching for package '%s' under url '%s'",
+                log.debug(" Searching for package '%s' under url '%s'",
                           dependency.name, url)
                 subprocess.check_call(git_cmd,
                                       stdout=subprocess.PIPE,
@@ -210,7 +211,11 @@ class Tools(object):
                 str_output = output
             output = str_output.splitlines()
             for pkg_line in output:
-                pkg_list.append(pkg_line.split(' ')[0])
+                pkg_line_list = pkg_line.split(' ')
+                pkg_name = pkg_line_list[0]
+                pkg_path = pkg_line_list[1]
+                if not pkg_path.startswith('/home/'):
+                    pkg_list.append(pkg_name)
             log.info(" [ROS]: Ignoring %s packages.", len(pkg_list))
             return set(pkg_list)
         except subprocess.CalledProcessError:

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup
 from setuptools import find_packages
 from setuptools.command.install import install
 
-version_str = '0.2.2'
+version_str = '0.2.3'
 
 # Setup installation dependencies
 install_requires = [

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup
 from setuptools import find_packages
 from setuptools.command.install import install
 
-version_str = '0.2.3'
+version_str = '0.3.0'
 
 # Setup installation dependencies
 install_requires = [
@@ -74,7 +74,6 @@ catkin workspace and updating all the packages to the final state.""",
     test_suite='tests',
     entry_points={
         'catkin_tools.commands.catkin.verbs': [
-            'fetch = catkin_tools_fetch:description',
             'deps = catkin_tools_fetch:description_deps',
             'dependencies = catkin_tools_fetch:description_dependencies',
         ],

--- a/tests/data/simple_pkg/package.xml
+++ b/tests/data/simple_pkg/package.xml
@@ -13,7 +13,7 @@
 
   <!-- The export tag contains other, unspecified, tags -->
   <export>
-    <git_url target="all" url="generic_link"/>
+    <git_url target="all" url="http_link_default"/>
     <git_url target="dep_1" url="http_link" />
     <git_url target="dep_2" url="git_link" branch="dev" />
   </export>

--- a/tests/data/simple_pkg/package.xml
+++ b/tests/data/simple_pkg/package.xml
@@ -13,6 +13,7 @@
 
   <!-- The export tag contains other, unspecified, tags -->
   <export>
+    <git_url target="all" url="generic_link"/>
     <git_url target="dep_1" url="http_link" />
     <git_url target="dep_2" url="git_link" branch="dev" />
   </export>

--- a/tests/data/simple_pkg/package.xml
+++ b/tests/data/simple_pkg/package.xml
@@ -13,7 +13,8 @@
 
   <!-- The export tag contains other, unspecified, tags -->
   <export>
-    <git_url target="all" url="http_link_default"/>
+    <git_url target="all" url="http_link_default_1"/>
+    <git_url target="all" url="http_link_default_2"/>
     <git_url target="dep_1" url="http_link" />
     <git_url target="dep_2" url="git_link" branch="dev" />
   </export>

--- a/tests/test_git_bridge.py
+++ b/tests/test_git_bridge.py
@@ -2,9 +2,12 @@
 import unittest
 import os
 import shutil
+import logging
 import tempfile
 from catkin_tools_fetch.lib.tools import GitBridge
 from catkin_tools_fetch.lib.dependency_parser import Dependency
+
+log = logging.getLogger('deps')
 
 
 class TestGitBridge(unittest.TestCase):

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1,8 +1,11 @@
 """Module to test the parser and dependencies."""
 import unittest
+import logging
 from os import path
 from catkin_tools_fetch.lib.dependency_parser import Parser
 from catkin_tools_fetch.lib.dependency_parser import Dependency
+
+log = logging.getLogger('deps')
 
 
 class TestParser(unittest.TestCase):
@@ -10,7 +13,7 @@ class TestParser(unittest.TestCase):
 
     def test_init(self):
         """Initialize the parser."""
-        parser = Parser("blah_{package}", "pkg_name")
+        parser = Parser(set(["blah_{package}"]), "pkg_name")
         self.assertEqual(Parser.XML_FILE_NAME, "package.xml")
         self.assertTrue("build_depend" in Parser.TAGS)
         self.assertEqual(parser.pkg_name, "pkg_name")
@@ -18,7 +21,7 @@ class TestParser(unittest.TestCase):
     def test_init_death(self):
         """Test that wrong initialization fails."""
         try:
-            Parser("blah", "pkg_name")
+            Parser(["blah"], "pkg_name")
             self.fail()
         except ValueError as e:
             self.assertTrue(isinstance(e, ValueError))
@@ -26,7 +29,7 @@ class TestParser(unittest.TestCase):
     def test_get_dependencies(self):
         """Test that parsing dependencies works."""
         pkg_folder = path.join(path.dirname(__file__), "data", "simple_pkg")
-        parser = Parser("{package}", "simple_pkg")
+        parser = Parser(set(["{package}"]), "simple_pkg")
         deps = parser.get_dependencies(pkg_folder)
         self.assertIn("dep_1", deps)
         self.assertIn("dep_2", deps)
@@ -41,7 +44,9 @@ class TestParser(unittest.TestCase):
         self.assertEqual(deps["dep_2"].branch, "dev")
 
         self.assertEqual(deps["dep_3"].name, "dep_3")
-        self.assertEqual(deps["dep_3"].url, "http_link_default/dep_3")
+        self.assertTrue(deps["dep_3"].url is None)
+        self.assertIn("http_link_default_1/dep_3", deps["dep_3"].default_urls)
+        self.assertIn("http_link_default_2/dep_3", deps["dep_3"].default_urls)
         self.assertIsNone(deps["dep_3"].branch)
 
 

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -26,7 +26,7 @@ class TestParser(unittest.TestCase):
     def test_get_dependencies(self):
         """Test that parsing dependencies works."""
         pkg_folder = path.join(path.dirname(__file__), "data", "simple_pkg")
-        parser = Parser("link_default/{package}", "simple_pkg")
+        parser = Parser("{package}", "simple_pkg")
         deps = parser.get_dependencies(pkg_folder)
         self.assertIn("dep_1", deps)
         self.assertIn("dep_2", deps)
@@ -41,7 +41,7 @@ class TestParser(unittest.TestCase):
         self.assertEqual(deps["dep_2"].branch, "dev")
 
         self.assertEqual(deps["dep_3"].name, "dep_3")
-        self.assertEqual(deps["dep_3"].url, "link_default/dep_3")
+        self.assertEqual(deps["dep_3"].url, "http_link_default/dep_3")
         self.assertIsNone(deps["dep_3"].branch)
 
 

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -7,22 +7,34 @@ from catkin_tools_fetch.lib.dependency_parser import Dependency
 class TestTools(unittest.TestCase):
     """Test various tools that come with the project."""
 
-    def test_prepare_default_url(self):
+    def test_prepare_default_urls(self):
         """Test formatting the default dir."""
-        test_url = ''
-        self.assertEqual(test_url, Tools.prepare_default_url(test_url))
-        test_url_git = 'git@path/'
-        self.assertEqual(test_url_git + '{package}' + '.git',
-                         Tools.prepare_default_url(test_url_git))
-        test_url_git = 'git@path'
-        self.assertEqual(test_url_git + '/{package}' + '.git',
-                         Tools.prepare_default_url(test_url_git))
-        test_url_http = 'https://path/'
-        self.assertEqual(test_url_http + '{package}',
-                         Tools.prepare_default_url(test_url_http))
-        test_url_http = 'https://path'
-        self.assertEqual(test_url_http + '/{package}',
-                         Tools.prepare_default_url(test_url_http))
+        urls = [
+            "git@path",                     # 0
+            "git@path2/",                   # 1
+            "https://path",                 # 2
+            "https://path2/",               # 3
+            "git@some_path.git",            # 4
+            "git@some_path/{package}.git",  # 5
+            "{package}"                     # 6
+        ]
+        urls_joined = ','.join(urls)
+        prepared_urls = Tools.prepare_default_urls(urls_joined)
+        self.assertIn(urls[0] + '/{package}' + '.git', prepared_urls)
+        self.assertIn(urls[1] + '{package}' + '.git', prepared_urls)
+        self.assertIn(urls[2] + '/{package}', prepared_urls)
+        self.assertIn(urls[3] + '{package}', prepared_urls)
+        self.assertNotIn(urls[4], prepared_urls)
+        self.assertIn(urls[5], prepared_urls)
+        self.assertIn(urls[6], prepared_urls)
+
+    def test_populate_urls_with_name(self):
+        """Test populating urls with names."""
+        urls = ['blah{package}', '{package}', 'blah']
+        populated = Tools.populate_urls_with_name(urls=urls, pkg_name='NAME')
+        self.assertIn('blahNAME', populated)
+        self.assertIn('NAME', populated)
+        self.assertNotIn('blah', populated)
 
     def test_decorate(self):
         """Test how we decorate something."""


### PR DESCRIPTION
This PR allows setting multiple default urls from within the `package.xml` file. This default urls are populated from all packages being downloaded and a list of those is being used.

- [x] Handle the case when multiple packages define a default url
- [x] Remove old interface for deps
- [x] Update Readme