### PR TITLE
Pull after fetch and remove unused strategy setting

### DIFF
--- a/catkin_tools_fetch/cli.py
+++ b/catkin_tools_fetch/cli.py
@@ -25,7 +25,6 @@ from catkin_tools_fetch.lib.dependency_parser import Parser
 from catkin_tools_fetch.lib.downloader import Downloader
 from catkin_tools_fetch.lib.tools import Tools
 from catkin_tools_fetch.lib.update import Updater
-from catkin_tools_fetch.lib.update import Strategy
 
 logging.basicConfig()
 log = logging.getLogger('deps')

--- a/catkin_tools_fetch/cli.py
+++ b/catkin_tools_fetch/cli.py
@@ -82,14 +82,6 @@ def prepare_arguments_deps(parser):
         Update the existing repositories to their latest state from remote."""
     parser_update = subparsers.add_parser(
         'update', help=update_help_msg, parents=[parent_parser])
-    config_update_group = parser_update.add_argument_group('Config')
-    conflict_help_msg = """ When we pull a git repository there can be
-        conflicts. We need to resolve them in some way. You can pick this here.
-        By default the plugin will use '%(default)s' strategy."""
-    config_update_group.add_argument('--on-conflict', '-r',
-                                     choices=Strategy.list_all(),
-                                     default=Strategy.IGNORE,
-                                     help=conflict_help_msg)
 
     update_pkg_group = parser_update.add_argument_group(
         'Packages',
@@ -105,6 +97,10 @@ def prepare_arguments_deps(parser):
     parser_fetch = subparsers.add_parser('fetch',
                                          help=fetch_help_msg,
                                          parents=[parent_parser])
+    parser_fetch.add_argument('--update',
+                              action='store_true',
+                              default=True,
+                              help="Update after fetch.")
     fetch_group = parser_fetch.add_argument_group(
         'Packages',
         'Control for which packages we fetch dependencies.')
@@ -155,7 +151,8 @@ def main(opts):
                      context=context,
                      default_urls=default_urls,
                      use_preprint=use_preprint,
-                     num_threads=opts.num_threads)
+                     num_threads=opts.num_threads,
+                     pull_after_fetch=opts.update)
     if opts.subverb == 'update':
         return update(packages=opts.packages,
                       workspace=opts.workspace,
@@ -200,7 +197,8 @@ def fetch(packages,
           context,
           default_urls,
           use_preprint,
-          num_threads):
+          num_threads,
+          pull_after_fetch):
     """Fetch dependencies of a package.
 
     Args:
@@ -271,4 +269,10 @@ def fetch(packages,
         if error_code != 0:
             global_error_code = error_code
         log.info(" New packages available. Process their dependencies now.")
+    if pull_after_fetch:
+        updater = Updater(ws_path=ws_path,
+                          packages=workspace_packages,
+                          use_preprint=use_preprint,
+                          num_threads=num_threads)
+        updater.update_packages(packages)
     return global_error_code

--- a/catkin_tools_fetch/lib/update.py
+++ b/catkin_tools_fetch/lib/update.py
@@ -137,19 +137,3 @@ class Updater(object):
             # this is a warning
             return colored(picked_tag, 'yellow')
         return colored(picked_tag, 'red')
-
-
-class Strategy(object):
-    """An enum of stategies for update."""
-
-    IGNORE = 'ignore'
-    ABORT = 'abort'
-    # STASH = 'stash'
-
-    @classmethod
-    def list_all(cls):
-        """List all strategies."""
-        all_strategies = [val for key, val in cls.__dict__.items()
-                          if not callable(getattr(cls, key))
-                          and not key.startswith("__")]
-        return all_strategies

--- a/catkin_tools_fetch/lib/update.py
+++ b/catkin_tools_fetch/lib/update.py
@@ -35,7 +35,6 @@ class Updater(object):
     def __init__(self,
                  ws_path,
                  packages,
-                 conflict_strategy,
                  use_preprint=True,
                  colored=True,
                  num_threads=4):
@@ -44,12 +43,10 @@ class Updater(object):
         Args:
             ws_path (str): Path to the workspace
             packages (dict(str)): Dictionary of packages to be downloaded
-            conflict_strategy (str): A strategy to handle conflicts
         """
         super(Updater, self).__init__()
         self.ws_path = ws_path
         self.packages = packages
-        self.conflict_strategy = conflict_strategy
         self.thread_pool = futures.ThreadPoolExecutor(max_workers=num_threads)
         self.printer = Printer()
         self.colored = colored

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup
 from setuptools import find_packages
 from setuptools.command.install import install
 
-version_str = '0.3.3'
+version_str = '0.3.4'
 
 # Setup installation dependencies
 install_requires = [

--- a/tests/test_updater.py
+++ b/tests/test_updater.py
@@ -5,7 +5,6 @@ import tempfile
 from termcolor import colored
 from mock import MagicMock, PropertyMock
 from catkin_tools_fetch.lib.update import Updater
-from catkin_tools_fetch.lib.update import Strategy
 from catkin_tools_fetch.lib.tools import GitBridge
 
 
@@ -47,19 +46,16 @@ class TestUpdater(unittest.TestCase):
         packages = {
             "test_folder": "package_dummy"
         }
-        conflict_strategy = "abort"
-        updater = Updater(ws_path, packages, conflict_strategy)
+        updater = Updater(ws_path, packages)
         self.assertEquals(ws_path, updater.ws_path)
         self.assertEquals(packages, updater.packages)
-        self.assertEquals(conflict_strategy, updater.conflict_strategy)
 
     def test_filter_packages(self):
         """Test filtering of packages."""
         ws_path = self.test_dir
         mock_list, all_packages = generate_mock_packages(3)
         selected_packages = [mock_list[0].name, mock_list[2].name]
-        conflict_strategy = "abort"
-        updater = Updater(ws_path, all_packages, conflict_strategy)
+        updater = Updater(ws_path, all_packages)
         filtered_packages = updater.filter_packages(selected_packages)
         expected_packages = {
             "folder_0": mock_list[0],
@@ -76,8 +72,7 @@ class TestUpdater(unittest.TestCase):
             "folder_3": "package_dummy_3",
         }
         selected_packages = None
-        conflict_strategy = "abort"
-        updater = Updater(ws_path, all_packages, conflict_strategy)
+        updater = Updater(ws_path, all_packages)
         filtered_packages = updater.filter_packages(selected_packages)
         self.assertEquals(all_packages, filtered_packages)
 
@@ -122,9 +117,3 @@ Already up-to-date.
         self.assertEquals(status_msgs[0][0], "pkg")
         self.assertEquals(status_msgs[0][1], colored(
             Updater.UP_TO_DATE_TAG, "green"))
-
-    def test_list_strategies(self):
-        """Test the list of all strategies."""
-        expected = set([Strategy.IGNORE, Strategy.ABORT])
-        actual = set(Strategy.list_all())
-        self.assertEquals(len(expected.symmetric_difference(actual)), 0)


### PR DESCRIPTION
This should close #14 

This is not the ideal way of doing this. Ideal way would be to pull the repo upon finding that the folder exists. Now we just do an additional step after we have performed a fetch. This is fine for now from my perspective.